### PR TITLE
Add .into() on output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ macro_rules! inject {
     ) => {
         impl From<$from> for $to {
             fn from(value: $from) -> Self {
-                Self { $($tof: value.$fromf(),)* }
+                Self { $($tof: value.$fromf().into(),)* }
             }
         }
     }


### PR DESCRIPTION
allows .into() type on the output of inject! macro